### PR TITLE
feat: Add Redis cache and queue manager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,22 @@ services:
       timeout: 5s
       retries: 5
 
+  # Redis Cache and Queue Manager
+  redis:
+    image: redis:7-alpine
+    container_name: mispesos-redis
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    networks:
+      - mispesos-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 networks:
   mispesos-network:
     driver: bridge
@@ -29,3 +45,5 @@ networks:
 volumes:
   postgres_data:
     name: mispesos-postgres-data
+  redis_data:
+    name: mispesos-redis-data


### PR DESCRIPTION
## Summary
Add Redis 7 Alpine as the second service in the incremental deployment strategy.

## Changes
- ✅ Redis 7 Alpine container with AOF persistence
- ✅ Health checks configured (`redis-cli ping`)
- ✅ Internal networking only (no external port exposure)
- ✅ Named volume `mispesos-redis-data` for persistence
- ✅ Follows same deployment pattern as PostgreSQL

## Technical Details
- **Image:** `redis:7-alpine`
- **Persistence:** AOF (Append-Only File) enabled
- **Network:** `mispesos-network` (internal)
- **Health Check:** Every 10s with 5 retries
- **Restart Policy:** `unless-stopped`

## Deployment
Once merged, the existing GitHub Actions workflow will automatically deploy both PostgreSQL and Redis to alvis-server.

No workflow changes needed - Redis requires no environment variables.

## Testing
After deployment, verify with:
```bash
docker compose ps
docker compose exec redis redis-cli ping
```

## Next Steps
After this PR, the next service will be **Ollama AI** (Container 3).